### PR TITLE
iOS SDK 4.8.1 release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,8 +31,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "SeatGeekSDKTG",
-            url: "https://seatgeek.jfrog.io/artifactory/sdk-ios/4.8.0/SeatGeekSDK.xcframework.zip",
-            checksum: "1e3e2c2fa4252cafd5b9864f744a00da0898956a38783adc3889edd215741daa"
+            url: "https://seatgeek.jfrog.io/artifactory/sdk-ios/4.8.1/SeatGeekSDK.xcframework.zip",
+            checksum: "938d408de741958fc8cc849b426336f5e5be0367425b955d2d0422eb556543a5"
         ),
         .binaryTarget(
             name: "SnapKitTarget",

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ SeatGeek SDK allows client integrators to bring ticketing experience into their 
 To integrate SeatGeekSDK into your Xcode project using Swift Package Manager, add it to the dependencies value of your `Package.swift`:
 
     dependencies: [
-        .package(url: "https://github.com/seatgeek/seatgeek-ios-sdk", from: "4.8.0")
+        .package(url: "https://github.com/seatgeek/seatgeek-ios-sdk", from: "4.8.1")
     ]
 
 SeatGeekSDK uses external dependencies. Here you can find a list of them along with versions. 


### PR DESCRIPTION
Release notes:
- Fixed 'No Tickets' state, which was previously displaying the Bulk Sell button incorrectly when there were no past or incoming tickets available
- Performance optimizations