### PR TITLE
iOS SDK 4.9.0 release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,8 +31,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "SeatGeekSDKTG",
-            url: "https://seatgeek.jfrog.io/artifactory/sdk-ios/4.8.1/SeatGeekSDK.xcframework.zip",
-            checksum: "938d408de741958fc8cc849b426336f5e5be0367425b955d2d0422eb556543a5"
+            url: "https://seatgeek.jfrog.io/artifactory/sdk-ios/4.9.0/SeatGeekSDK.xcframework.zip",
+            checksum: "097831f54953ca33e5abe7c65082d576381d13e4fd3b0022cc30077fe6ad3bb1"
         ),
         .binaryTarget(
             name: "SnapKitTarget",

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SeatGeek SDK allows client integrators to bring ticketing experience into their 
 
 ## Requirements
 - iOS 16.0+
-- XCode 16.0+
+- XCode 16.2+
 
 ## Features
 - Ability to view tickets, ticket history
@@ -33,7 +33,7 @@ SeatGeek SDK allows client integrators to bring ticketing experience into their 
 #### Swift Package Manager
 [Swift Package Manager](https://www.swift.org/package-manager/) is a tool for managing the distribution of Swift code. It’s integrated with the Swift build system to automate the process of downloading, compiling, and linking dependencies.
 
->Xcode 16.0+ is required to build the SeatGeekSDK using Swift Package Manager
+>Xcode 16.2+ is required to build the SeatGeekSDK using Swift Package Manager.
 
 ## Step I
 


### PR DESCRIPTION
**Changelog:**
- Introduced two centralized mechanisms for client apps to manage SeatGeek SDK integration: responding to key actions occurring within the SDK and listening for a stream of events that can be used for analytics.
- Show a scan indicator on tickets. Fans will be able to differentiate between scanned and unscanned tickets to avoid confusion at the gate.
- Xcode 16.2 support.
- Removed unintended padding between the SDK nav bar and the tickets list.
- Made internal improvements and refactored code.
- Increased code coverage with automated tests.